### PR TITLE
Handle file removal on upload delete

### DIFF
--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\UploadSpreadsheetFile;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 
 class UploadController extends Controller
@@ -50,7 +51,10 @@ class UploadController extends Controller
 
     public function destroy(UploadSpreadsheetFile $uploadSpreadsheetFile)
     {
+        Storage::delete($uploadSpreadsheetFile->path);
         $uploadSpreadsheetFile->delete();
-        return redirect()->route('upload.list')->with('success', 'Arquivo excluído com sucesso!');
+
+        return redirect()->route('upload.list')
+            ->with('success', 'Arquivo excluído com sucesso!');
     }
 }

--- a/tests/Feature/Upload/DeleteUploadTest.php
+++ b/tests/Feature/Upload/DeleteUploadTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\UploadSpreadsheetFile;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('deletes the file and the record', function () {
+    Storage::fake('local');
+
+    Storage::disk('local')->put('uploads/test.txt', 'dummy');
+
+    $upload = UploadSpreadsheetFile::create([
+        'name' => 'test.txt',
+        'path' => 'uploads/test.txt',
+    ]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->delete(route('upload.destroy', $upload))
+        ->assertRedirect(route('upload.list', absolute: false));
+
+    $this->assertDatabaseMissing('upload_spreadsheet_files', [
+        'id' => $upload->id,
+    ]);
+
+    Storage::disk('local')->assertMissing('uploads/test.txt');
+});


### PR DESCRIPTION
## Summary
- delete files from storage when destroying an upload
- test deleting upload removes record and file

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b2ff43b4833189ad59f74e795d05