### PR TITLE
Ajusta rotas e controller de uploads

### DIFF
--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -27,7 +27,7 @@ class UploadController extends Controller
         ]);
     }
 
-    public function form()
+    public function create()
     {
         return Inertia::render('upload/index');
     }
@@ -46,7 +46,7 @@ class UploadController extends Controller
             'path' => $path,
         ]);
 
-        return redirect()->route('upload.index')->with('success', 'Arquivo enviado com sucesso!');
+        return redirect()->route('uploads.index')->with('success', 'Arquivo enviado com sucesso!');
     }
 
     public function destroy(UploadSpreadsheetFile $uploadSpreadsheetFile)
@@ -54,7 +54,7 @@ class UploadController extends Controller
         Storage::delete($uploadSpreadsheetFile->path);
         $uploadSpreadsheetFile->delete();
 
-        return redirect()->route('upload.list')
+        return redirect()->route('uploads.index')
             ->with('success', 'Arquivo excluído com sucesso!');
     }
 }

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -15,7 +15,7 @@ const mainNavItems: NavItem[] = [
     },
     {
         title: 'Upload',
-        href: '/upload',
+        href: '/uploads',
         icon: LayoutGrid,
     },
 ];

--- a/resources/js/pages/upload/UploadDataTable.tsx
+++ b/resources/js/pages/upload/UploadDataTable.tsx
@@ -32,14 +32,14 @@ export default function UploadDataTable({ uploads, filters }: PageProps) {
   const [openId, setOpenId] = React.useState<number | null>(null)
 
   const handleDelete = (id: number) => {
-    router.delete(route('upload.destroy', id), {
+    router.delete(route('uploads.destroy', id), {
       preserveScroll: true,
     })
   }
 
   const handleSort = (column: string) => {
     const isAsc = filters.sort === column && filters.direction === 'asc'
-    router.get(route('upload.list'), {
+    router.get(route('uploads.index'), {
       sort: column,
       direction: isAsc ? 'desc' : 'asc',
     }, {

--- a/resources/js/pages/upload/index.tsx
+++ b/resources/js/pages/upload/index.tsx
@@ -7,7 +7,7 @@ import { type BreadcrumbItem } from '@/types'
 import { useRef } from 'react'
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Upload', href: '/upload' },
+    { title: 'Upload', href: '/uploads' },
 ]
 
 interface FlashData{
@@ -27,7 +27,7 @@ export default function UploadPage() {
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault()
-        post(route('upload.store'), {
+        post(route('uploads.store'), {
             forceFormData: true,
             onSuccess: () => {
                 setData('file', null)

--- a/resources/js/pages/upload/list.tsx
+++ b/resources/js/pages/upload/list.tsx
@@ -5,8 +5,8 @@ import UploadDataTable from '@/pages/upload/uploadDataTable'
 import Pagination from '@/components/ui/pagination'
 
 const breadcrumbs: BreadcrumbItem[] = [
-  { title: 'Upload', href: '/upload' },
-  { title: 'Listagem', href: '/upload/list' },
+  { title: 'Upload', href: '/uploads' },
+  { title: 'Listagem', href: '/uploads' },
 ]
 
 export default function UploadListPage({ uploads, filters }: any) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,10 +12,10 @@ Route::get('/', function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard',[DashboardController::class, 'index'])->name('dashboard');
 
-    Route::get('/upload', [UploadController::class, 'form'])->name('upload.index');
-    Route::post('/upload', [UploadController::class, 'store'])->name('upload.store');
-    Route::get('/upload/list', [UploadController::class, 'index'])->name('upload.list');
-    Route::delete('/upload/{uploadSpreadsheetFile}', [UploadController::class, 'destroy'])->name('upload.destroy');
+    Route::get('/uploads', [UploadController::class, 'index'])->name('uploads.index');
+    Route::get('/uploads/create', [UploadController::class, 'create'])->name('uploads.create');
+    Route::post('/uploads', [UploadController::class, 'store'])->name('uploads.store');
+    Route::delete('/uploads/{uploadSpreadsheetFile}', [UploadController::class, 'destroy'])->name('uploads.destroy');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/Upload/DeleteUploadTest.php
+++ b/tests/Feature/Upload/DeleteUploadTest.php
@@ -19,8 +19,8 @@ it('deletes the file and the record', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
-        ->delete(route('upload.destroy', $upload))
-        ->assertRedirect(route('upload.list', absolute: false));
+        ->delete(route('uploads.destroy', $upload))
+        ->assertRedirect(route('uploads.index', absolute: false));
 
     $this->assertDatabaseMissing('upload_spreadsheet_files', [
         'id' => $upload->id,


### PR DESCRIPTION
## Summary
- atualiza UploadController para usar metodo `create`
- redefine rotas em `web.php` no padrao resource
- atualiza links do menu e breadcrumbs
- ajusta chamadas das rotas no frontend
- corrige teste de delecao conforme novas rotas

## Testing
- `php artisan test --compact` *(fails: php not installed)*
- `npm test --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855b5a12aa4833195567ecbd2d7179d