### PR TITLE
Add PDF selection for OpenAI chat

### DIFF
--- a/app/Http/Controllers/OpenAIController.php
+++ b/app/Http/Controllers/OpenAIController.php
@@ -2,18 +2,41 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\UploadSpreadsheetFile;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Inertia\Inertia;
 
 class OpenAIController extends Controller
 {
+    public function index()
+    {
+        $pdfFiles = UploadSpreadsheetFile::where('path', 'like', '%.pdf')
+            ->get(['id', 'name']);
+
+        return Inertia::render('openai/index', [
+            'pdfFiles' => $pdfFiles,
+        ]);
+    }
+
     public function send(Request $request)
     {
         $validated = $request->validate([
             'messages' => 'required|array',
             'messages.*.role' => 'required|in:user,assistant,system',
             'messages.*.content' => 'required|string',
+            'pdf_id' => 'nullable|integer|exists:upload_spreadsheet_files,id',
         ]);
+
+        if (!empty($validated['pdf_id'])) {
+            $pdf = UploadSpreadsheetFile::find($validated['pdf_id']);
+            if ($pdf) {
+                $validated['messages'][] = [
+                    'role' => 'user',
+                    'content' => 'Arquivo selecionado: ' . $pdf->name,
+                ];
+            }
+        }
 
         $response = Http::withToken(config('services.openai.key'))
             ->post('https://api.openai.com/v1/chat/completions', [

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -4,7 +4,7 @@ import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, Bot } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -17,6 +17,11 @@ const mainNavItems: NavItem[] = [
         title: 'Upload',
         href: '/uploads',
         icon: LayoutGrid,
+    },
+    {
+        title: 'OpenAI Chat',
+        href: '/openai',
+        icon: Bot,
     },
 ];
 

--- a/resources/js/pages/openai/index.tsx
+++ b/resources/js/pages/openai/index.tsx
@@ -1,9 +1,16 @@
 import { useState } from 'react'
-import { Head, router } from '@inertiajs/react'
+import { Head } from '@inertiajs/react'
 import AppLayout from '@/layouts/app-layout'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { type BreadcrumbItem } from '@/types'
 import axios from 'axios'
 
@@ -11,16 +18,26 @@ const breadcrumbs: BreadcrumbItem[] = [
   { title: 'OpenAI', href: '/openai' },
 ]
 
+interface PdfFile {
+  id: number
+  name: string
+}
+
+interface PageProps {
+  pdfFiles: PdfFile[]
+}
+
 interface ChatMessage {
   role: 'user' | 'assistant' | 'system'
   content: string
 }
 
-export default function OpenAIChatPage() {
+export default function OpenAIChatPage({ pdfFiles }: PageProps) {
   const [context, setContext] = useState('')
   const [message, setMessage] = useState('')
   const [history, setHistory] = useState<ChatMessage[]>([])
   const [loading, setLoading] = useState(false)
+  const [selectedPdf, setSelectedPdf] = useState('')
 
   const handleSend = async () => {
     if (!message.trim()) return
@@ -40,6 +57,7 @@ export default function OpenAIChatPage() {
     try {
         const res = await axios.post(route('openai.send'), {
             messages: newHistory,
+            pdf_id: selectedPdf || null,
         })
 
         const assistantReply = res.data.choices?.[0]?.message
@@ -64,6 +82,23 @@ export default function OpenAIChatPage() {
             onChange={(e) => setContext(e.target.value)}
             placeholder="Descreva o contexto da conversa..."
           />
+        </div>
+
+        <div className="space-y-2">
+          <label className="font-medium">Arquivo PDF (opcional)</label>
+          <Select value={selectedPdf} onValueChange={setSelectedPdf}>
+            <SelectTrigger>
+              <SelectValue placeholder="Selecione um PDF" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Nenhum</SelectItem>
+              {pdfFiles.map((file) => (
+                <SelectItem key={file.id} value={String(file.id)}>
+                  {file.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="border-t pt-4 space-y-4 max-h-[50vh] overflow-y-auto pr-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/uploads', [UploadController::class, 'store'])->name('uploads.store');
     Route::delete('/uploads/{uploadSpreadsheetFile}', [UploadController::class, 'destroy'])->name('uploads.destroy');
 
-    Route::get('/openai', fn () => Inertia::render('openai/index'))->name('openai.index');
+    Route::get('/openai', [OpenAIController::class, 'index'])->name('openai.index');
     Route::post('/openai/send-message', [OpenAIController::class, 'send'])->name('openai.send');
 });
 


### PR DESCRIPTION
## Summary
- allow PDF selection in OpenAI chat page
- support `pdf_id` in OpenAIController and list uploaded PDFs
- update sidebar menu with link to chat
- wire route to controller

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: numerous missing dependencies)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fd43e19483318888fbada433bb6c